### PR TITLE
trying to cache apt 

### DIFF
--- a/config/settings/ci.py
+++ b/config/settings/ci.py
@@ -70,4 +70,3 @@ DEFAULT_FROM_EMAIL = (
 ###########
 
 # no logging in ci
-


### PR DESCRIPTION
Played around w/ caching `apt` packages in the "build.yml" action.  In the end, it was just more trouble than it's worth.